### PR TITLE
Some errors I noticed

### DIFF
--- a/tutorials_previous/5_tensorflow_traffic_light_classification.ipynb
+++ b/tutorials_previous/5_tensorflow_traffic_light_classification.ipynb
@@ -226,7 +226,7 @@
    "source": [
     "# Our loss function and optimizer\n",
     "\n",
-    "loss = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(y, y_))\n",
+    "loss = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(labels = y_, logits = y))\n",
     "train_step = tf.train.AdamOptimizer(1e-4).minimize(loss)\n",
     "sess.run(tf.initialize_all_variables())"
    ]
@@ -340,7 +340,7 @@
     "for i in range(0, max_epochs):\n",
     "\n",
     "    # Iterate over our training set\n",
-    "    for tt in range(0, (len(train_x) / batch_size)):\n",
+    "    for tt in range(0, (len(train_x) // batch_size)):\n",
     "        start_batch = batch_size * tt\n",
     "        end_batch = batch_size * (tt + 1)\n",
     "        train_step.run(feed_dict={x: train_x[start_batch:end_batch], y_: train_y[start_batch:end_batch]})\n",


### PR DESCRIPTION
since we cannot iterate through a float its better we take the floor division of 
(len(train_x) / batch_size) ==> (len(train_x) // batch_size)

can't specify softmax_cross_entropy_with_logits without labels or logits  
tf.nn.softmax_cross_entropy_with_logits( y, y_) ==> tf.nn.softmax_cross_entropy_with_logits(labels = y_, logits = y)